### PR TITLE
Chore/fix demo relative images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build
 .github
 .husky
 .env
+
+# Local Netlify folder
+.netlify

--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:ci": "NEXT_PUBLIC_UPLOADCARE_APP_BASE_URL=$DEPLOY_PRIME_URL NODE_ENV=production next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -109,6 +109,9 @@ export function uploadcareLoader({
 
     // Return the relative url AS IS if the base path is not set.
     if (!isBasePathSet) {
+      console.warn(
+        'Env variable "NEXT_PUBLIC_UPLOADCARE_APP_BASE_URL" is not set. You should set it to be able to serve local images.'
+      );
       return src;
     }
 


### PR DESCRIPTION
Inject `NEXT_PUBLIC_UPLOADCARE_APP_BASE_URL` into the netlify build to be able to proxify local-hosted images through Uploadcare Proxy CDN. 

It's not working now on the deploy preview due to some troubles related to adding netlify.com domain to the allowed domains list. Will be OK on the production deploy.